### PR TITLE
fix: cd command now moves to home (~) instead of root (/)

### DIFF
--- a/src/exec.rs
+++ b/src/exec.rs
@@ -577,7 +577,9 @@ where
 
     match cmd.program {
         "cd" => {
-            let dir = cmd.args.first().copied().unwrap_or("/");
+            let dir = cmd.args.first().map(std::path::PathBuf::from).unwrap_or_else(|| {
+                std::env::var("HOME").map(std::path::PathBuf::from).unwrap_or_else(|_| std::path::PathBuf::from("/"))
+            });
             std::env::set_current_dir(dir)?;
             exec_noop(channels, ctx)
         }


### PR DESCRIPTION
Fixes an issue where the `cd` command would go to root (`/`) instead of the user's home directory (`~`).

https://github.com/user-attachments/assets/1de5aaf0-b243-473c-b46e-26695bd701e8

